### PR TITLE
circle-ci: set global git user for git tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
-workspace_root: &workspace_root /go/src/github.com/gruntwork-io/git-xargs
 defaults: &defaults
-  working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.13
-
   environment: 
     TERRATEST_LOG_PARSER_VERSION: NONE
     TERRAFORM_VERSION: NONE
@@ -40,24 +37,13 @@ jobs:
           command: run-go-tests --timeout 45m
           no_output_timeout: 45m
           when: always
-  build:
+  build-and-deploy:
     <<: *defaults
     steps:
       - checkout
-      - attach_workspace: 
-          at: *workspace_root
       - run: 
           <<: *install_gruntwork_utils
       - run: build-go-binaries --app-name git-xargs --src-path ./cmd --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
-      - persist_to_workspace: 
-          root: *workspace_root
-          paths: bin
-  deploy: 
-    <<: *defaults
-    steps: 
-      - checkout
-      - attach_workspace: 
-          at: *workspace_root
       - run: cd bin && sha256sum * > SHA256SUMS
       - run: upload-github-release-assets bin/* 
 workflows:
@@ -70,21 +56,13 @@ workflows:
               only: /^v.*/
           context:
             - Gruntwork Admin
-      - build:
+      - build-and-deploy:
           requires:
             - test
           filters:
             tags:
               only: /^v.*/
-          context:
-            - Gruntwork Admin
-      - deploy: 
-          requires: 
-            - build
-          filters: 
-            tags: 
-              only: /^v.*/
             branches: 
               ignore: /.*/
-          context: 
+          context:
             - Gruntwork Admin


### PR DESCRIPTION
The circle ci env needs an arbitrary git user's email and name set by the time the tests that interact with the locally created and ultimately discarded embedded test git repo run.

These changes result in the test phase passing. Digging into the release build failures on a separate branch.