### PR TITLE
fix: updating go.mod path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gruntwork-io/prototypes/git-xargs
+module github.com/gruntwork-io/git-xargs
 
 go 1.14
 


### PR DESCRIPTION
# Description

Throwing this PR out there; feel free to close it if it's not relevant.

I tried running the following commands to install the CLI tool, but they all failed.

<details>
<summary>Build from source commands</summary>

```console
$ go get -u -v github.com/gruntwork-io/git-xargs

go get: github.com/gruntwork-io/git-xargs@none updating to
    github.com/gruntwork-io/git-xargs@v0.0.3: parsing go.mod:
    module declares its path as: github.com/gruntwork-io/prototypes/git-xargs
            but was required as: github.com/gruntwork-io/git-xargs

$ go get -u -v github.com/gruntwork-io/git-xargs/cmd

go get: github.com/gruntwork-io/git-xargs@none updating to
    github.com/gruntwork-io/git-xargs@v0.0.3: parsing go.mod:
    module declares its path as: github.com/gruntwork-io/prototypes/git-xargs
            but was required as: github.com/gruntwork-io/git-xargs

$ go get -u -v github.com/gruntwork-io/prototypes/git-xargs

go get: module github.com/gruntwork-io/prototypes/git-xargs: git ls-remote -q origin in /Users/<my-user>/go/pkg/mod/cache/vcs/71e6a51a31709f8c15acf32385e11303f8c35b3ab4f6c4457aa458e205a40d1d: exit status 128:
    ERROR: Repository not found.
    fatal: Could not read from remote repository.

    Please make sure you have the correct access rights
    and the repository exists.
```

</details>

The `go.mod` path needs to be updated to support building from source.