### PR TITLE
Allow reading repo names via stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 git-xargs
 test-repo/
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can handle these use cases and many more with a single `git-xargs` command.
 As an example, let's use `git-xargs` to create a new file in every repo:
 
 ```
-./git-xargs \
+git-xargs \
   --branch-name test-branch \
   --github-org <your-github-org> \
   --commit-message "Create hello-world.txt" \
@@ -129,39 +129,42 @@ COMMAND SUPPLIED
 
 ## Getting started
 
-### 1. Export a valid Github token
+1. **Export a valid Github token**. See the guide on [Github personal access 
+   tokens](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) 
+   for information on how to generate one. For example, on Linux or Mac, you'd run:
 
-See the guide on [Github personal access tokens](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) for information on how to generate one.
+    ```bash
+    export GITHUB_OAUTH_TOKEN=<your-secret-github-oauth-token>
+    ```
 
-```
-export GITHUB_OAUTH_TOKEN=<your-secret-github-oauth-token>
-```
+1. **Download the correct binary for your platform**. Visit [the releases 
+   page](https://github.com/gruntwork-io/git-xargs/releases) and download the correct binary depending on your system.
+   Save it to somewhere on your `PATH`, such as `/usr/local/bin/git-xargs`. 
 
-### 2. Download the correct binary for your platform
+1. **Set execute permissions**. For example, on Linux or Mac, you'd run:
 
-Visit [the releases page](https://github.com/gruntwork-io/git-xargs/releases) and download the correct binary depending on your system. For example, you might opt to save it to `/usr/local/bin/git-xargs`. 
+    ```bash
+    chmod u+x /usr/local/bin/git-xargs
+    ```
 
-### 3. Set the correct permissions
+1. **Check it's working**. Run the version command to ensure everything is working properly:
 
-`chmod u+x /usr/local/bin/git-xargs`
+    ```bash
+    git-xargs --version
+    ```
 
-### 4. Run the version command to ensure everything is working properly
+1. **Provide a script or command and target some repos**. Here's a simple example of running the `touch` command in 
+   every repo in your Github organization. Follow the same pattern to start running your own scripts and commands 
+   against your own repos!
 
-```
-git-xargs --version
-```
+    ```bash
+    git-xargs \
+      --branch-name "test-branch" \
+      --commit-message "Testing git-xargs" \
+      --github-org <enter-your-github-org-name> \
+      touch git-xargs-is-awesome.txt
+    ```
 
-### 5. Provide a script or command and target some repos
-
-Here's a simple example of running a touch commnand in every repo in your Github organization. Follow the same pattern to start running your own scripts and commands against your own repos!
-
-```
-git-xargs \
-  --branch-name "test-branch" \
-  --commit-message "Testing git-xargs" \
-  --github-org <enter-your-github-org-name> \
-  touch git-xargs-is-awesome.txt
-```
 # Reference
 
 ## How to supply commands or scripts to run
@@ -169,7 +172,7 @@ git-xargs \
 The API for `git-xargs` is:
 
 ```
-./git-xargs [-flags] <CMD>
+git-xargs [-flags] <CMD>
 ```
 
 Where `CMD` is either the full path to a (Bash, Python, Ruby) etc script on your local system or a binary. Note that, because the tool supports Bash scripts, Ruby scripts, Python scripts, etc, you must include the full filename for any given script, including its file extension.
@@ -177,20 +180,20 @@ Where `CMD` is either the full path to a (Bash, Python, Ruby) etc script on your
 In other words, all the following usages are valid:
 
 ```
-./git-xargs --repo --repo gruntwork-io/cloud-nuke \
+git-xargs --repo --repo gruntwork-io/cloud-nuke \
    --repo gruntwork-io/terraform-aws-eks \
    --branch-name my-branch \
    /usr/local/bin/my-bash-script.sh
 ```
 
 ```
-./git-xargs --repos ./my-repos.txt \
+git-xargs --repos ./my-repos.txt \
   --branch-name my-other-branch \
   touch file1.txt file2.txt
 ```
 
 ```
-./git-xargs --github-org my-github-org \ 
+git-xargs --github-org my-github-org \ 
   --branch-name my-new-branch \
   "$(pwd)/scripts/my-ruby-script.rb"
 ```
@@ -208,7 +211,7 @@ Currently, `git-xargs` will find and add any and all new files, as well as any e
 Scripts may be placed anywhere on your system, but you are responsible for providing absolute paths to your scripts when invoking `git-xargs`:
 
 ```
-./git-xargs \
+git-xargs \
   --branch-name upgrade-tf-14 \
   --commit-message "Update modules to Terraform 0.14" \
   --repos data/batch3.txt \
@@ -217,7 +220,7 @@ Scripts may be placed anywhere on your system, but you are responsible for provi
 or
 
 ```
-./git-xargs \
+git-xargs \
   --branch-name upgrade-tf-14 \
   --commit-message "Update modules to Terraform 0.14" \
   --repos data/batch3.txt \
@@ -235,7 +238,7 @@ the order listed below, with whichever option is found first being used, and all
 If you want the tool to find and select every repo in your Github organization, you can pass the name of your organization via the `--github-org` flag:
 
 ```
-./git-xargs \
+git-xargs \
   --commit-message "Update copyright year" \
   --github-org <your-github-org> \ 
   "$(pwd)/scripts/update-copyright-year.sh"
@@ -248,7 +251,7 @@ This will signal the tool to look up, and page through, every repository in your
 Oftentimes, you want finer-grained control over the exact repos you are going to run your script against. In this case, you can use the `--repos` flag and supply the path to a file defining the exact repos you want the tool to run your selected scripts against, like so:
 
 ```
-./git-xargs \
+git-xargs \
   --commit-mesage "Update copyright year" \
   --repos data/batch2.txt \
   "$(pwd)/scripts/update-copyright-year.sh"
@@ -271,7 +274,7 @@ Another way to get fine-grained control is to pass in the individual repos you w
 arguments:
 
 ```
-./git-xargs \
+git-xargs \
   --commit-mesage "Update copyright year" \
   --repo gruntwork-io/terragrunt \
   --repo gruntwork-io/terratest \
@@ -292,7 +295,7 @@ echo "gruntwork-io/terragrunt gruntwork-io/terratest" | git-xargs \
 
 ## Notable flags
 
-`git-xargs` exposes several flags that allow you to customize its behavior to better suit your needs. For the latest info on flags, you should run `./git-xargs --help`. However, a couple of the flags are worth explaining more in depth here:
+`git-xargs` exposes several flags that allow you to customize its behavior to better suit your needs. For the latest info on flags, you should run `git-xargs --help`. However, a couple of the flags are worth explaining more in depth here:
 
 |Flag|Description|Type|Required|
 |---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ If you need to compose more complex behavior into a single pull request, write a
 
 ## How to target repos to run your scripts against
 
-`git-xargs` supports **two** methods of targeting repos to run your selected scripts against. Note that you **must** select one or the other option when running `git-xargs`, meaning you must either pass `--repos` or `--github-org` as demonstrated below:
+`git-xargs` supports **four** methods of targeting repos to run your selected scripts against. They are processed in
+the order listed below, with whichever option is found first being used, and all others after it being ignored.
 
 ### Option #1: Github organization lookup
 If you want the tool to find and select every repo in your Github organization, you can pass the name of your organization via the `--github-org` flag:
@@ -263,6 +264,31 @@ gruntwork-io/infrastructure-modules-multi-account-acme
 ```
 
 Flat files contain one repo per line, each repository in the format of `<github-organization>/<repo-name>`. Commas, trailing or preceding spaces, and quotes are all filtered out at runtime. This is done in case you end up copying your repo list from a JSON list or CSV file.
+
+### Option #3: Pass in repos via command line args
+
+Another way to get fine-grained control is to pass in the individual repos you want to use via one or more `--repo` 
+arguments:
+
+```
+./git-xargs \
+  --commit-mesage "Update copyright year" \
+  --repo gruntwork-io/terragrunt \
+  --repo gruntwork-io/terratest \
+  --repo gruntwork-io/cloud-nuke \
+  "$(pwd)/scripts/update-copyright-year.sh"
+```
+
+### Option #4: Pass in repos via stdin
+
+And one more (Unix-philosophy friendly) way to get fine-grained control is to pass in the individual repos you want to 
+use by piping them in via `stdin`, separating repo names with whitespace or newlines:
+
+```
+echo "gruntwork-io/terragrunt gruntwork-io/terratest" | git-xargs \
+  --commit-mesage "Update copyright year" \
+  "$(pwd)/scripts/update-copyright-year.sh"
+```
 
 ## Notable flags
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -41,7 +41,6 @@ var (
 	genericBranchFlag = cli.StringFlag{
 		Name:     BranchFlagName,
 		Usage:    "The name of the branch on which changes will be made",
-		Required: true,
 	}
 	genericCommitMessageFlag = cli.StringFlag{
 		Name:  CommitMessageFlagName,

--- a/cmd/git-xargs.go
+++ b/cmd/git-xargs.go
@@ -156,6 +156,11 @@ func sanityCheckInputs(config *GitXargsConfig) error {
 
 // runGitXargs is the urfave cli app's Action that is called when the user executes the binary
 func runGitXargs(c *cli.Context) error {
+	// If someone calls us with no args at all, show the help text and exit
+	if !c.Args().Present() {
+		return cli.ShowAppHelp(c)
+	}
+
 	logger := logging.GetLogger("git-xargs")
 
 	logger.Info("git-xargs running...")

--- a/cmd/git-xargs_test.go
+++ b/cmd/git-xargs_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,4 +22,35 @@ func TestHandleRepoProcessing(t *testing.T) {
 	err := handleRepoProcessing(config)
 
 	assert.NoError(t, err)
+}
+
+func TestParseSliceFromReader(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"empty string", "", []string{}},
+		{"one string", "foo", []string{"foo"}},
+		{"one string with whitespace", "    foo\t\t\t", []string{"foo"}},
+		{"multiple strings separated by whitespace", "foo bar     baz\t\tblah", []string{"foo", "bar", "baz", "blah"}},
+		{"multiple strings separated by newlines", "foo\nbar\nbaz\nblah", []string{"foo", "bar", "baz", "blah"}},
+		{"multiple strings separated by newlines, with extra newlines", "\n\nfoo\nbar\n\nbaz\nblah\n\n\n", []string{"foo", "bar", "baz", "blah"}},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := parseSliceFromReader(strings.NewReader(testCase.input))
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,13 +14,19 @@ func TestSetupApp(t *testing.T) {
 	assert.NotNil(t, app)
 }
 
-func TestGitXargsRejectsEmptyArgs(t *testing.T) {
+func TestGitXargsShowsHelpTextForEmptyArgs(t *testing.T) {
 	app := setupApp()
+
+	// Capture the app's stdout
+	var stdout strings.Builder
+	app.Writer = &stdout
 
 	emptyFlagSet := flag.NewFlagSet("git-xargs-test", flag.ContinueOnError)
 	emptyTestContext := cli.NewContext(app, emptyFlagSet, nil)
 
 	err := runGitXargs(emptyTestContext)
 
-	assert.Error(t, err)
+	// Make sure we see the help text
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), app.Description)
 }

--- a/cmd/select-repos.go
+++ b/cmd/select-repos.go
@@ -188,8 +188,7 @@ func OperateOnRepos(config *GitXargsConfig) error {
 		// Update count of number of repos the the tool read in from the provided file
 		config.Stats.SetFileProvidedRepos(repoSelection.GetAllowedRepos())
 
-	case ExplicitReposOnCommandLine:
-
+	case ExplicitReposOnCommandLine, ReposViaStdIn:
 		githubRepos, err := fetchUserProvidedReposViaGithubAPI(config.GithubClient, *repoSelection, config.Stats)
 		if err != nil {
 			return err

--- a/cmd/select-repos.go
+++ b/cmd/select-repos.go
@@ -11,24 +11,29 @@ import (
 type RepoSelectionCriteria string
 
 const (
+	ReposViaStdIn              RepoSelectionCriteria = "repo-stdin"
 	ExplicitReposOnCommandLine RepoSelectionCriteria = "repo-flag"
 	ReposFilePath              RepoSelectionCriteria = "repos-file"
 	GithubOrganization         RepoSelectionCriteria = "github-org"
 )
 
-// getPreferredOrderOfRepoSelections codifies the order in which flags will be preferred when the user supplied more than one:
-// 1. --repo is a string slice flag that can be called multiple times, and is preferred first when present
-// 2. --repos is a string representing a filepath to a repos file and will be accepted if --repo is not passed
-// 3. -- github-org is a string representing the Github org to page through via API for all repos - it will be accepted
-// if the other flags are not passed
+// getPreferredOrderOfRepoSelections codifies the order in which flags will be preferred when the user supplied more
+// than one:
+// 1. --github-org is a string representing the Github org to page through via API for all repos.
+// 2. --repos is a string representing a filepath to a repos file
+// 3. --repo is a string slice flag that can be called multiple times
+// 4. stdin allows you to pipe repos in from other CLI tools
 func getPreferredOrderOfRepoSelections(config *GitXargsConfig) RepoSelectionCriteria {
-	if len(config.RepoSlice) > 0 {
-		return ExplicitReposOnCommandLine
+	if config.GithubOrg != "" {
+		return GithubOrganization
 	}
 	if config.ReposFile != "" {
 		return ReposFilePath
 	}
-	return GithubOrganization
+	if len(config.RepoSlice) > 0 {
+		return ExplicitReposOnCommandLine
+	}
+	return ReposViaStdIn
 }
 
 // RepoSelection is a struct that presents a uniform interface to present to OperateRepos that converts
@@ -87,13 +92,25 @@ func selectReposViaInput(config *GitXargsConfig) (*RepoSelection, error) {
 	case GithubOrganization:
 		return def, nil
 
+	case ReposViaStdIn:
+		allowedRepos, err := selectReposViaRepoFlag(config.RepoFromStdIn)
+		if err != nil {
+			return def, err
+		}
+		return &RepoSelection{
+			SelectionType:          ReposViaStdIn,
+			AllowedRepos:           allowedRepos,
+			GithubOrganizationName: "",
+		}, nil
+
 	default:
 		return def, nil
 	}
 }
 
-// selectReposViaRepoFlag converts the string slice of repo flags provided by invocations of the --repo flag
-// into the internal representation of AllowedRepo that we we use prior to fetching the corresponding repo from Github
+// selectReposViaRepoFlag converts the string slice of repo flags provided via stdin or by invocations of the --repo
+// flag into the internal representation of AllowedRepo that we we use prior to fetching the corresponding repo from
+// Github
 func selectReposViaRepoFlag(inputRepos []string) ([]*AllowedRepo, error) {
 	var allowedRepos []*AllowedRepo
 

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -41,7 +41,7 @@ func (NoGithubOrgSuppliedErr) Error() string {
 type NoRepoSelectionsMadeErr struct{}
 
 func (NoRepoSelectionsMadeErr) Error() string {
-	return fmt.Sprint("You must target some repos for processing by providing one of the --github-org, --repos, or --repo flags")
+	return fmt.Sprint("You must target some repos for processing either via stdin or by providing one of the --github-org, --repos, or --repo flags")
 }
 
 type NoReposFoundErr struct {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -44,6 +44,12 @@ func (NoRepoSelectionsMadeErr) Error() string {
 	return fmt.Sprint("You must target some repos for processing either via stdin or by providing one of the --github-org, --repos, or --repo flags")
 }
 
+type NoBranchNameErr struct{}
+
+func (NoBranchNameErr) Error() string {
+	return fmt.Sprint("You must pass a branch name to use via the --branch-name flag")
+}
+
 type NoReposFoundErr struct {
 	GithubOrg string
 }

--- a/cmd/types_test.go
+++ b/cmd/types_test.go
@@ -17,7 +17,7 @@ func TestCustomErrorStatements(t *testing.T) {
 	assert.Equal(t, "You must pass a valid Github organization name", errNoGithubOrg.Error())
 
 	errNoRepoSelected := &NoRepoSelectionsMadeErr{}
-	assert.Equal(t, "You must target some repos for processing by providing one of the --github-org, --repos, or --repo flags", errNoRepoSelected.Error())
+	assert.Equal(t, "You must target some repos for processing either via stdin or by providing one of the --github-org, --repos, or --repo flags", errNoRepoSelected.Error())
 
 	errNoReposFound := &NoReposFoundErr{GithubOrg: "gruntwork-io"}
 	assert.Equal(t, "No repos found for the organization supplied via --github-org: gruntwork-io", errNoReposFound.Error())

--- a/cmd/validate-input.go
+++ b/cmd/validate-input.go
@@ -4,7 +4,7 @@ import "github.com/gruntwork-io/go-commons/errors"
 
 // Sanity check that user has provided one valid method for selecting repos to operate on
 func ensureValidOptionsPassed(config *GitXargsConfig) error {
-	if len(config.RepoSlice) < 1 && config.ReposFile == "" && config.GithubOrg == "" {
+	if len(config.RepoSlice) < 1 && config.ReposFile == "" && config.GithubOrg == "" && len(config.RepoFromStdIn) == 0 {
 		return errors.WithStackTrace(NoRepoSelectionsMadeErr{})
 	}
 	return nil

--- a/cmd/validate-input.go
+++ b/cmd/validate-input.go
@@ -7,5 +7,8 @@ func ensureValidOptionsPassed(config *GitXargsConfig) error {
 	if len(config.RepoSlice) < 1 && config.ReposFile == "" && config.GithubOrg == "" && len(config.RepoFromStdIn) == 0 {
 		return errors.WithStackTrace(NoRepoSelectionsMadeErr{})
 	}
+	if config.BranchName == "" {
+		return errors.WithStackTrace(NoBranchNameErr{})
+	}
 	return nil
 }

--- a/cmd/validate-input_test.go
+++ b/cmd/validate-input_test.go
@@ -47,9 +47,10 @@ func TestEnsureValidOptionsPassedAcceptedValidSingleRepo(t *testing.T) {
 func TestEnsureValidOptionsPassedAcceptsAllFlagsSimultaneously(t *testing.T) {
 	t.Parallel()
 	testConfigWithAllSelectionCriteria := &GitXargsConfig{
-		ReposFile: "./my-repos.txt",
-		RepoSlice: []string{"gruntwork-io/cloud-nuke", "gruntwork-io/fetch"},
-		GithubOrg: "github-org",
+		ReposFile:     "./my-repos.txt",
+		RepoSlice:     []string{"gruntwork-io/cloud-nuke", "gruntwork-io/fetch"},
+		GithubOrg:     "github-org",
+		RepoFromStdIn: []string{"gruntwork-io/terragrunt"},
 	}
 
 	err := ensureValidOptionsPassed(testConfigWithAllSelectionCriteria)

--- a/cmd/validate-input_test.go
+++ b/cmd/validate-input_test.go
@@ -47,6 +47,7 @@ func TestEnsureValidOptionsPassedAcceptedValidSingleRepo(t *testing.T) {
 func TestEnsureValidOptionsPassedAcceptsAllFlagsSimultaneously(t *testing.T) {
 	t.Parallel()
 	testConfigWithAllSelectionCriteria := &GitXargsConfig{
+		BranchName:    "test-branch",
 		ReposFile:     "./my-repos.txt",
 		RepoSlice:     []string{"gruntwork-io/cloud-nuke", "gruntwork-io/fetch"},
 		GithubOrg:     "github-org",

--- a/cmd/validate-input_test.go
+++ b/cmd/validate-input_test.go
@@ -17,7 +17,7 @@ func TestEnsureValidOptionsPassedRejectsEmptySelectors(t *testing.T) {
 func TestEnsureValidOptionsPassedAcceptsValidGithubOrg(t *testing.T) {
 	t.Parallel()
 	testConfigWithGithubOrg := &GitXargsConfig{
-		BranchName: "text-branch",
+		BranchName: "test-branch",
 		GithubOrg:  "gruntwork-io",
 	}
 

--- a/cmd/validate-input_test.go
+++ b/cmd/validate-input_test.go
@@ -17,7 +17,8 @@ func TestEnsureValidOptionsPassedRejectsEmptySelectors(t *testing.T) {
 func TestEnsureValidOptionsPassedAcceptsValidGithubOrg(t *testing.T) {
 	t.Parallel()
 	testConfigWithGithubOrg := &GitXargsConfig{
-		GithubOrg: "gruntwork-io",
+		BranchName: "text-branch",
+		GithubOrg:  "gruntwork-io",
 	}
 
 	err := ensureValidOptionsPassed(testConfigWithGithubOrg)
@@ -27,7 +28,8 @@ func TestEnsureValidOptionsPassedAcceptsValidGithubOrg(t *testing.T) {
 func TestEnsureValidOptionsPassedAcceptsValidReposFile(t *testing.T) {
 	t.Parallel()
 	testConfigWithReposFile := &GitXargsConfig{
-		ReposFile: "./my-repos.txt",
+		BranchName: "test-branch",
+		ReposFile:  "./my-repos.txt",
 	}
 
 	err := ensureValidOptionsPassed(testConfigWithReposFile)
@@ -37,7 +39,8 @@ func TestEnsureValidOptionsPassedAcceptsValidReposFile(t *testing.T) {
 func TestEnsureValidOptionsPassedAcceptedValidSingleRepo(t *testing.T) {
 	t.Parallel()
 	testConfigWithExplicitRepos := &GitXargsConfig{
-		RepoSlice: []string{"gruntwork-io/cloud-nuke"},
+		BranchName: "test-branch",
+		RepoSlice:  []string{"gruntwork-io/cloud-nuke"},
 	}
 
 	err := ensureValidOptionsPassed(testConfigWithExplicitRepos)


### PR DESCRIPTION
I was using `git-xargs` today and wanted to be able to pass in repo names via `stdin`, so I took a few minutes and implemented it. This fixes #8.

Other bonus tweaks:

1. The order of preference for how to pass in repos is now: `--github-org`, `--repos`, `--repo`, `stdin`. My thinking was to go from easiest to hardest. Not super attached to this, so feedback welcome.
1. Added `stdin` to README. Also added missing `--repo` option. 
1. Make getting started steps a bit shorter / more compact, so they are easier to follow.
1. Remove unnecessary `./` from `git-xargs` examples in README.
1. Show help text if you run `git-xargs` with no arguments at all.

Do we have an integration test that actually runs the `git-xargs` CLI? If so, I could add a test that passes in repos via `stdin`. But as it is, I don't see any easy way to test that?