### PR TITLE
fix: Use the repo default branch as base when opening a PR

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -89,7 +89,7 @@ func processRepo(config *GitXargsConfig, repo *github.Repository) error {
 		return pushBranchErr
 	}
 
-	// Open a pull request on Github, of the recently pushed branch against master
+	// Open a pull request on Github, of the recently pushed branch against the repository default branch
 	openPullRequestErr := openPullRequest(config, repo, branchName.String())
 	if openPullRequestErr != nil {
 		return openPullRequestErr

--- a/cmd/repo-operations.go
+++ b/cmd/repo-operations.go
@@ -362,11 +362,13 @@ func openPullRequest(config *GitXargsConfig, repo *github.Repository, branch str
 		}
 	}
 
+	repoDefaultBranch := repo.GetDefaultBranch()
+
 	// Configure pull request options that the Github client accepts when making calls to open new pull requests
 	newPR := &github.NewPullRequest{
 		Title:               github.String(titleToUse),
 		Head:                github.String(branch),
-		Base:                github.String("master"),
+		Base:                github.String(repoDefaultBranch),
 		Body:                github.String(descriptionToUse),
 		MaintainerCanModify: github.Bool(true),
 	}
@@ -378,7 +380,7 @@ func openPullRequest(config *GitXargsConfig, repo *github.Repository, branch str
 		logger.WithFields(logrus.Fields{
 			"Error": err,
 			"Head":  branch,
-			"Base":  "master",
+			"Base":  repoDefaultBranch,
 			"Body":  descriptionToUse,
 		}).Debug("Error opening Pull request")
 


### PR DESCRIPTION
Encountered that issue when running git-xargs and trying to create a PR on a repository that uses `main` as default branch.