### PR TITLE
Fix stdout/stderr handling

### DIFF
--- a/cmd/_testscripts/test-stdout-stderr.rb
+++ b/cmd/_testscripts/test-stdout-stderr.rb
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+# This scripts writes some text to stdout and stderr and then exits with an error. This is used to test that git-xargs
+# always logs the stdout and stderr from scripts, even if those scripts exit with an error.
 
 STDOUT.puts('Hello, from STDOUT')
 STDERR.puts('Hello, from STDERR')
+exit 1

--- a/cmd/_testscripts/test-stdout-stderr.rb
+++ b/cmd/_testscripts/test-stdout-stderr.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+STDOUT.puts('Hello, from STDOUT')
+STDERR.puts('Hello, from STDERR')

--- a/cmd/_testscripts/test-stdout-stderr.sh
+++ b/cmd/_testscripts/test-stdout-stderr.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 # This scripts writes some text to stdout and stderr and then exits with an error. This is used to test that git-xargs
 # always logs the stdout and stderr from scripts, even if those scripts exit with an error.
 
-STDOUT.puts('Hello, from STDOUT')
-STDERR.puts('Hello, from STDERR')
+echo 'Hello, from STDOUT'
+>&2 echo 'Hello, from STDERR'
 exit 1

--- a/cmd/_testscripts/test-stdout-stderr.sh
+++ b/cmd/_testscripts/test-stdout-stderr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This scripts writes some text to stdout and stderr and then exits with an error. This is used to test that git-xargs
+# This script writes some text to stdout and stderr and then exits with an error. This is used to test that git-xargs
 # always logs the stdout and stderr from scripts, even if those scripts exit with an error.
 
 echo 'Hello, from STDOUT'

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -72,13 +72,13 @@ func processRepo(config *GitXargsConfig, repo *github.Repository) error {
 	}
 
 	//Run the specified command
-	commandErr := executeCommand(config, repositoryDir, repo, worktree)
+	commandErr := executeCommand(config, repositoryDir, repo)
 	if commandErr != nil {
 		return commandErr
 	}
 
 	// Commit any untracked files, modified or deleted files that resulted from script execution
-	commitErr := commitLocalChanges(config, worktree, repo, localRepository)
+	commitErr := commitLocalChanges(config, repositoryDir, worktree, repo, localRepository)
 	if commitErr != nil {
 		return commitErr
 	}

--- a/cmd/repo-operations_test.go
+++ b/cmd/repo-operations_test.go
@@ -33,7 +33,7 @@ func TestExecuteCommandWithLogger(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewGitXargsConfig()
-	cfg.Args = []string{"./_testscripts/test-stdout-stderr.rb"}
+	cfg.Args = []string{"./_testscripts/test-stdout-stderr.sh"}
 
 	repo := getMockGithubRepo()
 

--- a/cmd/repo-operations_test.go
+++ b/cmd/repo-operations_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/google/go-github/v32/github"
@@ -27,7 +27,8 @@ func getMockGithubRepo() *github.Repository {
 	return repo
 }
 
-// Test that we can execute a script and that the expected stdout and stderr get written to the logger
+// Test that we can execute a script and that the expected stdout and stderr get written to the logger, even if that
+// script exits with an error (exit status 1).
 func TestExecuteCommandWithLogger(t *testing.T) {
 	t.Parallel()
 
@@ -44,7 +45,7 @@ func TestExecuteCommandWithLogger(t *testing.T) {
 	}
 
 	err := executeCommandWithLogger(cfg, ".", repo, logger)
-	require.NoError(t, err)
-	require.Contains(t, buffer.String(), "Hello, from STDOUT")
-	require.Contains(t, buffer.String(), "Hello, from STDERR")
+	assert.Errorf(t, err, "exit status 1")
+	assert.Contains(t, buffer.String(), "Hello, from STDOUT")
+	assert.Contains(t, buffer.String(), "Hello, from STDERR")
 }

--- a/cmd/repo-operations_test.go
+++ b/cmd/repo-operations_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v32/github"
 )
 
@@ -27,29 +25,6 @@ func getMockGithubRepo() *github.Repository {
 	}
 
 	return repo
-}
-
-func cloneLocalTestRepo(t *testing.T) (string, *git.Repository) {
-	repo := getMockGithubRepo()
-
-	config := NewGitXargsTestConfig()
-
-	localPath, localRepo, err := cloneLocalRepository(config, repo)
-
-	if err != nil {
-		t.Logf("Could not clone local repo to localPath: %s\n", localPath)
-		t.Fail()
-	}
-
-	return localPath, localRepo
-}
-
-func cleanupLocalTestRepo(t *testing.T, localPath string) error {
-	removeErr := os.RemoveAll(localPath)
-	if removeErr != nil {
-		t.Logf("Error cleaning up test repo at path: %s err: %+v\n", localPath, removeErr)
-	}
-	return removeErr
 }
 
 // Test that we can execute a script and that the expected stdout and stderr get written to the logger


### PR DESCRIPTION
This PR fixes #24. It ensures that `git-xargs` always logs `stdout` / `stderr` from the script, even if the script exits with an error. I've added a test for this too.

Other tweaks in this PR:

1. Refactor `executeCommand` to _only_ run the command. This makes it easier to test this method.
1. Move the `git add` logic that used to be in `executeCommand` into `commitLocalChanges`. This is the more logical home for it.
1. If the work tree reports that the status is clean, don't try to commit anything in `commitLocalChanges`. Previously, the work tree status was only checked in `executeCommand`, and `commitLocalChanges` would try to commit whether or not the status was clean, which was _probably_ a no op, but doesn't seem right.
1. Remove some unused test functions. 