### PR TITLE
Don't try to open PR if one is already open

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -14,6 +14,7 @@ import (
 // The go-github package satisfies this PullRequest service's interface in production
 type githubPullRequestService interface {
 	Create(ctx context.Context, owner string, name string, pr *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
+	List(ctx context.Context, owner string, repo string, opts *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error)
 }
 
 // The go-github package satisfies this Repositories service's interface in production

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -53,6 +53,10 @@ func (m mockGithubPullRequestService) Create(ctx context.Context, owner, name st
 	return m.PullRequest, m.Response, nil
 }
 
+func (m mockGithubPullRequestService) List(ctx context.Context, owner string, repo string, opts *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
+	return []*github.PullRequest{m.PullRequest}, m.Response, nil
+}
+
 // This mocks the Repositories service in go-github that is used in production to call the associated Github endpoint
 type mockGithubRepositoriesService struct {
 	Repository   *github.Repository

--- a/repository/process.go
+++ b/repository/process.go
@@ -78,22 +78,9 @@ func processRepo(config *config.GitXargsConfig, repo *github.Repository) error {
 		return commandErr
 	}
 
-	// Commit any untracked files, modified or deleted files that resulted from script execution
-	commitErr := commitLocalChanges(config, repositoryDir, worktree, repo, localRepository)
-	if commitErr != nil {
-		return commitErr
-	}
-
-	// Push the local branch containing all of our changes from executing the supplied command
-	pushBranchErr := pushLocalBranch(config, repo, localRepository)
-	if pushBranchErr != nil {
-		return pushBranchErr
-	}
-
-	// Open a pull request on Github, of the recently pushed branch against the repository default branch
-	openPullRequestErr := openPullRequest(config, repo, branchName.String())
-	if openPullRequestErr != nil {
-		return openPullRequestErr
+	// Commit and push the changes to Git and open a PR
+	if err := updateRepo(config, repositoryDir, worktree, repo, localRepository, branchName.String()); err != nil {
+		return err
 	}
 
 	return nil

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -457,7 +457,9 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 // Returns true if a pull request already exists in the given repo for the given branch
 func pullRequestAlreadyExistsForBranch(config *config.GitXargsConfig, repo *github.Repository, branch string, repoDefaultBranch string) (bool, error) {
 	opts := &github.PullRequestListOptions{
-		Head: branch,
+		// Filter pulls by head user or head organization and branch name in the format of user:ref-name or organization:ref-name
+		// https://docs.github.com/en/rest/reference/pulls#list-pull-requests
+		Head: fmt.Sprintf("%s:%s", *repo.Owner.Login, branch),
 		Base: repoDefaultBranch,
 	}
 

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -400,6 +400,9 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 			"Head": branch,
 			"Base": repoDefaultBranch,
 		}).Debug("Pull request already exists for this branch, so skipping opening a pull request!")
+
+		// Track that we skipped opening a pull request
+		config.Stats.TrackSingle(stats.PullRequestAlreadyExists, repo)
 		return nil
 	}
 

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -459,7 +459,7 @@ func pullRequestAlreadyExistsForBranch(config *config.GitXargsConfig, repo *gith
 	opts := &github.PullRequestListOptions{
 		// Filter pulls by head user or head organization and branch name in the format of user:ref-name or organization:ref-name
 		// https://docs.github.com/en/rest/reference/pulls#list-pull-requests
-		Head: fmt.Sprintf("%s:%s", *repo.Owner.Login, branch),
+		Head: fmt.Sprintf("%s:%s", *repo.GetOwner().Login, branch),
 		Base: repoDefaultBranch,
 	}
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -54,6 +54,8 @@ const (
 	RepoNotExists types.Event = "repo-not-exists"
 	// PullRequestOpenErr denotes a repo whose pull request containing config changes could not be made successfully
 	PullRequestOpenErr types.Event = "pull-request-open-error"
+	// PullRequestAlreadyExists denotes a repo where the pull request already exists for the requested branch, so we didn't open a new one
+	PullRequestAlreadyExists types.Event = "pull-request-already-exists"
 	// CommitsMadeDirectlyToBranch denotes a repo whose local worktree changes were committed directly to the specified branch because the --skip-pull-requests flag was passed
 	CommitsMadeDirectlyToBranch types.Event = "commits-made-directly-to-branch"
 	//DirectCommitsPushedToRemoteBranch denotes a repo whose changes were pushed to the remote specified branch because the --skip-pull-requests flag was passed
@@ -84,6 +86,7 @@ var allEvents = []types.AnnotatedEvent{
 	{Event: PushBranchSkipped, Description: "Repos whose local branch was not pushed because the --dry-run flag was set"},
 	{Event: RepoNotExists, Description: "Repos that were supplied by user but don't exist (404'd) via Github API"},
 	{Event: PullRequestOpenErr, Description: "Repos against which pull requests failed to be opened"},
+	{Event: PullRequestAlreadyExists, Description: "Repos where opening a pull request was skipped because a pull request was already open"},
 	{Event: CommitsMadeDirectlyToBranch, Description: "Repos whose local changes were committed directly to the specified branch because --skip-pull-requests was passed"},
 	{Event: DirectCommitsPushedToRemoteBranch, Description: "Repos whose changes were pushed directly to the remote branch because --skip-pull-requests was passed"},
 	{Event: BranchRemotePullFailed, Description: "Repos whose remote branches could not be successfully pulled"},


### PR DESCRIPTION
Fixes #32.

Key changes:

1. Check if a PR already exists for a given branch before trying to open up a new one. 
1. Refactor the code a bit into a `updateRepo` method so that if the working tree reports itself as clean, we don't try to commit, push, or open a PR at all.