### PR TITLE
Improve display of stdout/stderr for command

### DIFF
--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -111,9 +111,7 @@ func executeCommandWithLogger(config *config.GitXargsConfig, repositoryDir strin
 
 	stdoutStdErr, err := cmd.CombinedOutput()
 
-	logger.WithFields(logrus.Fields{
-		"CombinedOutput": string(stdoutStdErr),
-	}).Debug("Received output of command run")
+	logger.Debugf("Output of command %v for repo %s in directory %s:\n%s", config.Args, repo.GetName(), repositoryDir, string(stdoutStdErr))
 
 	if err != nil {
 		logger.WithFields(logrus.Fields{


### PR DESCRIPTION
Update `git-xargs` to write the `stdout` / `stderr` from the command directly to the logs, as plain text, rather than using structured logging / logrus fields. The problem with using fields, as we did before, is the log output gets shoved into JSON, with all sorts of characters escaped (e.g., newlines become `\n`), which makes it hard to read the log output when debugging.