### PR TITLE
feat: Add --draft flag for draft pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Oftentimes, you want finer-grained control over the exact repos you are going to
 
 ```
 git-xargs \
-  --commit-mesage "Update copyright year" \
+  --commit-message "Update copyright year" \
   --repos data/batch2.txt \
   "$(pwd)/scripts/update-copyright-year.sh"
 ```
@@ -340,7 +340,7 @@ arguments:
 
 ```
 git-xargs \
-  --commit-mesage "Update copyright year" \
+  --commit-message "Update copyright year" \
   --repo gruntwork-io/terragrunt \
   --repo gruntwork-io/terratest \
   --repo gruntwork-io/cloud-nuke \
@@ -354,7 +354,7 @@ use by piping them in via `stdin`, separating repo names with whitespace or newl
 
 ```
 echo "gruntwork-io/terragrunt gruntwork-io/terratest" | git-xargs \
-  --commit-mesage "Update copyright year" \
+  --commit-message "Update copyright year" \
   "$(pwd)/scripts/update-copyright-year.sh"
 ```
 
@@ -374,6 +374,7 @@ echo "gruntwork-io/terragrunt gruntwork-io/terratest" | git-xargs \
 | `--skip-archived-repos`  | If you want to exclude archived (read-only) repositories from the list of targeted repos, pass this flag.                                                                                                                                                                                                                                                                                                                      | Boolean | No       |
 | `--dry-run`              | If you are in the process of testing out `git-xargs` or your intial set of targeted repos, but you don't want to make any changes via the Github API (pushing your local changes or opening pull requests) you can pass the dry-run branch. This is useful because the output report will still tell you which repos would have been affected, without actually making changes via the Github API to your remote repositories. | Boolean | No       |
 | `--max-concurrent-repos` | Limits the number of concurrent processed repositories. This is only useful if you encounter issues and need throttling when running on a very large number of repos. Default is `0` (Unlimited)                                                                                                                                                                                                                               | Integer | No       |
+| `--draft` | Whether to open pull requests in draft mode. Draft pull requests are available for public GitHub repositories and private repositories in GitHub tiered accounts. See [Draft Pull Requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) for more details.  | Boolean | No |
 
 ## Best practices, tips and tricks
 

--- a/cmd/git-xargs.go
+++ b/cmd/git-xargs.go
@@ -20,8 +20,8 @@ import (
 // to an internal representation of the data supplied by the user
 func parseGitXargsConfig(c *cli.Context) (*config.GitXargsConfig, error) {
 	config := config.NewGitXargsConfig()
-	config.DryRun = c.Bool("dry-run")
 	config.Draft = c.Bool("draft")
+	config.DryRun = c.Bool("dry-run")
 	config.SkipPullRequests = c.Bool("skip-pull-requests")
 	config.SkipArchivedRepos = c.Bool("skip-archived-repos")
 	config.BranchName = c.String("branch-name")

--- a/cmd/git-xargs.go
+++ b/cmd/git-xargs.go
@@ -21,6 +21,7 @@ import (
 func parseGitXargsConfig(c *cli.Context) (*config.GitXargsConfig, error) {
 	config := config.NewGitXargsConfig()
 	config.DryRun = c.Bool("dry-run")
+	config.Draft = c.Bool("draft")
 	config.SkipPullRequests = c.Bool("skip-pull-requests")
 	config.SkipArchivedRepos = c.Bool("skip-archived-repos")
 	config.BranchName = c.String("branch-name")

--- a/common/common.go
+++ b/common/common.go
@@ -4,6 +4,7 @@ import "github.com/urfave/cli"
 
 const (
 	GithubOrgFlagName              = "github-org"
+	DraftPullRequestFlagName       = "draft"
 	DryRunFlagName                 = "dry-run"
 	SkipPullRequestsFlagName       = "skip-pull-requests"
 	SkipArchivedReposFlagName      = "skip-archived-repos"
@@ -24,6 +25,10 @@ var (
 	GenericGithubOrgFlag = cli.StringFlag{
 		Name:  GithubOrgFlagName,
 		Usage: "The Github organization to fetch all repositories from.",
+	}
+	GenericDraftPullRequestFlag = cli.BoolFlag{
+		Name:  DraftPullRequestFlagName,
+		Usage: "Whether to open pull requests in draft mode",
 	}
 	GenericDryRunFlag = cli.BoolFlag{
 		Name:  DryRunFlagName,

--- a/config/config.go
+++ b/config/config.go
@@ -12,10 +12,11 @@ import (
 
 // GitXargsConfig is the internal representation of a given git-xargs run as specified by the user
 type GitXargsConfig struct {
+	Draft                  bool
 	DryRun                 bool
 	SkipPullRequests       bool
 	SkipArchivedRepos      bool
-	MaxConcurrentRepos	   int
+	MaxConcurrentRepos     int
 	BranchName             string
 	CommitMessage          string
 	PullRequestTitle       string
@@ -33,6 +34,7 @@ type GitXargsConfig struct {
 // NewGitXargsConfig sets reasonable defaults for a GitXargsConfig and returns a pointer to a the config
 func NewGitXargsConfig() *GitXargsConfig {
 	return &GitXargsConfig{
+		Draft:                  false,
 		DryRun:                 false,
 		SkipPullRequests:       false,
 		SkipArchivedRepos:      false,

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func setupApp() *cli.App {
 	app.Flags = []cli.Flag{
 		LogLevelFlag,
 		common.GenericGithubOrgFlag,
+		common.GenericDraftPullRequestFlag,
 		common.GenericDryRunFlag,
 		common.GenericSkipPullRequestFlag,
 		common.GenericSkipArchivedReposFlag,

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -82,6 +82,16 @@ func PrintRepoReport(allEvents []types.AnnotatedEvent, runReport *types.RunRepor
 		pullRequests = append(pullRequests, pr)
 	}
 
+	var draftPullRequests []types.PullRequest
+
+	for repoName, prURL := range runReport.DraftPullRequests {
+		pr := types.PullRequest{
+			Repo: repoName,
+			URL:  prURL,
+		}
+		draftPullRequests = append(draftPullRequests, pr)
+	}
+
 	if len(pullRequests) > 0 {
 		fmt.Println()
 		fmt.Println("*****************************************************")
@@ -90,6 +100,18 @@ func PrintRepoReport(allEvents []types.AnnotatedEvent, runReport *types.RunRepor
 		pullRequestPrinter := tableprinter.New(os.Stdout)
 		configurePrinterStyling(pullRequestPrinter)
 		pullRequestPrinter.Print(pullRequests)
+		fmt.Println()
+
+	}
+
+	if len(draftPullRequests) > 0 {
+		fmt.Println()
+		fmt.Println("*****************************************************")
+		fmt.Println("  DRAFT PULL REQUESTS OPENED")
+		fmt.Println("*****************************************************")
+		pullRequestPrinter := tableprinter.New(os.Stdout)
+		configurePrinterStyling(pullRequestPrinter)
+		pullRequestPrinter.Print(draftPullRequests)
 		fmt.Println()
 
 	}

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -435,8 +435,6 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 		}
 	}
 
-	draft := config.Draft
-
 	// Configure pull request options that the Github client accepts when making calls to open new pull requests
 	newPR := &github.NewPullRequest{
 		Title:               github.String(titleToUse),
@@ -444,7 +442,7 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 		Base:                github.String(repoDefaultBranch),
 		Body:                github.String(descriptionToUse),
 		MaintainerCanModify: github.Bool(true),
-		Draft:               github.Bool(draft),
+		Draft:               github.Bool(config.Draft),
 	}
 
 	// Make a pull request via the Github API
@@ -456,7 +454,6 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 			"Head":  branch,
 			"Base":  repoDefaultBranch,
 			"Body":  descriptionToUse,
-			"Draft": draft,
 		}).Debug("Error opening Pull request")
 
 		// Track pull request open failure

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -445,10 +445,14 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 		Draft:               github.Bool(config.Draft),
 	}
 
-	// Make a pull request via the GitHub API
-	pr, _, err := config.GithubClient.PullRequests.Create(context.Background(), *repo.GetOwner().Login, repo.GetName(), newPR)
+	// Make a pull request via the Github API
+	pr, resp, err := config.GithubClient.PullRequests.Create(context.Background(), *repo.GetOwner().Login, repo.GetName(), newPR)
 
 	if err != nil {
+		if resp.StatusCode == 422 {
+			config.Stats.TrackSingle(stats.RepoNotCompatibleWithPullConfig, repo)
+		}
+
 		logger.WithFields(logrus.Fields{
 			"Error": err,
 			"Head":  branch,

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -53,7 +53,7 @@ func cloneLocalRepository(config *config.GitXargsConfig, repo *github.Repository
 	})
 
 	logger.WithFields(logrus.Fields{
-		"Repo":  repo.GetName(),
+		"Repo": repo.GetName(),
 	}).Debug(gitProgressBuffer)
 
 	if err != nil {
@@ -196,7 +196,7 @@ func checkoutLocalBranch(config *config.GitXargsConfig, ref *plumbing.Reference,
 	}
 
 	logger.WithFields(logrus.Fields{
-		"Repo":  remoteRepository.GetName(),
+		"Repo": remoteRepository.GetName(),
 	}).Debug(gitProgressBuffer)
 
 	pullErr := worktree.Pull(po)
@@ -435,6 +435,8 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 		}
 	}
 
+	draft := config.Draft
+
 	// Configure pull request options that the Github client accepts when making calls to open new pull requests
 	newPR := &github.NewPullRequest{
 		Title:               github.String(titleToUse),
@@ -442,6 +444,7 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 		Base:                github.String(repoDefaultBranch),
 		Body:                github.String(descriptionToUse),
 		MaintainerCanModify: github.Bool(true),
+		Draft:               github.Bool(draft),
 	}
 
 	// Make a pull request via the Github API
@@ -453,6 +456,7 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 			"Head":  branch,
 			"Base":  repoDefaultBranch,
 			"Body":  descriptionToUse,
+			"Draft": draft,
 		}).Debug("Error opening Pull request")
 
 		// Track pull request open failure

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -66,6 +66,8 @@ const (
 	BranchRemotePullFailed types.Event = "branch-remote-pull-failed"
 	// BranchRemoteDidntExistYet denotes a repo whose specified branch didn't exist remotely yet and so was just created locally to begin with
 	BranchRemoteDidntExistYet types.Event = "branch-remote-didnt-exist-yet"
+	// RepoNotCompatibleWithPullConfig denotes a repo that is incompatible with the submitted pull request configuration
+	RepoNotCompatibleWithPullConfig types.Event = "repo-not-compatible-with-pull-config"
 )
 
 var allEvents = []types.AnnotatedEvent{
@@ -94,6 +96,7 @@ var allEvents = []types.AnnotatedEvent{
 	{Event: DirectCommitsPushedToRemoteBranch, Description: "Repos whose changes were pushed directly to the remote branch because --skip-pull-requests was passed"},
 	{Event: BranchRemotePullFailed, Description: "Repos whose remote branches could not be successfully pulled"},
 	{Event: BranchRemoteDidntExistYet, Description: "Repos whose specified branches did not exist on the remote, and so were first created locally"},
+	{Event: RepoNotCompatibleWithPullConfig, Description: "Repos where the submitted pull request configuration is not compatible with the repo"},
 }
 
 // RunStats will be a stats-tracker class that keeps score of which repos were touched, which were considered for update, which had branches made, PRs made, which were missing workflows or contexts, or had out of date workflows syntax values, etc

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -66,7 +66,7 @@ const (
 	BranchRemotePullFailed types.Event = "branch-remote-pull-failed"
 	// BranchRemoteDidntExistYet denotes a repo whose specified branch didn't exist remotely yet and so was just created locally to begin with
 	BranchRemoteDidntExistYet types.Event = "branch-remote-didnt-exist-yet"
-  // RepoFlagSuppliedRepoMalformed denotes a repo passed via the --repo flag that was malformed (perhaps missing it's Github org prefix) and therefore unprocessable
+	// RepoFlagSuppliedRepoMalformed denotes a repo passed via the --repo flag that was malformed (perhaps missing it's Github org prefix) and therefore unprocessable
 	RepoFlagSuppliedRepoMalformed types.Event = "repo-flag-supplied-repo-malformed"
 	// RepoNotCompatibleWithPullConfig denotes a repo that is incompatible with the submitted pull request configuration
 	RepoNotCompatibleWithPullConfig types.Event = "repo-not-compatible-with-pull-config"
@@ -99,7 +99,7 @@ var allEvents = []types.AnnotatedEvent{
 	{Event: BranchRemotePullFailed, Description: "Repos whose remote branches could not be successfully pulled"},
 	{Event: BranchRemoteDidntExistYet, Description: "Repos whose specified branches did not exist on the remote, and so were first created locally"},
 	{Event: RepoFlagSuppliedRepoMalformed, Description: "Repos passed via the --repo flag that were malformed (missing their Github org prefix?) and therefore unprocessable"},
-  {Event: RepoNotCompatibleWithPullConfig, Description: "Repos where the submitted pull request configuration is not compatible with the repo"},
+	{Event: RepoNotCompatibleWithPullConfig, Description: "Repos where the submitted pull request configuration is not compatible with the repo"},
 }
 
 // RunStats will be a stats-tracker class that keeps score of which repos were touched, which were considered for update, which had branches made, PRs made, which were missing workflows or contexts, or had out of date workflows syntax values, etc

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -68,8 +68,8 @@ const (
 	BranchRemoteDidntExistYet types.Event = "branch-remote-didnt-exist-yet"
 	// RepoFlagSuppliedRepoMalformed denotes a repo passed via the --repo flag that was malformed (perhaps missing it's Github org prefix) and therefore unprocessable
 	RepoFlagSuppliedRepoMalformed types.Event = "repo-flag-supplied-repo-malformed"
-	// RepoNotCompatibleWithPullConfig denotes a repo that is incompatible with the submitted pull request configuration
-	RepoNotCompatibleWithPullConfig types.Event = "repo-not-compatible-with-pull-config"
+	// RepoDoesntSupportDraftPullRequestsErr denotes a repo that is incompatible with the submitted pull request configuration
+	RepoDoesntSupportDraftPullRequestsErr types.Event = "repo-not-compatible-with-pull-config"
 )
 
 var allEvents = []types.AnnotatedEvent{
@@ -99,7 +99,7 @@ var allEvents = []types.AnnotatedEvent{
 	{Event: BranchRemotePullFailed, Description: "Repos whose remote branches could not be successfully pulled"},
 	{Event: BranchRemoteDidntExistYet, Description: "Repos whose specified branches did not exist on the remote, and so were first created locally"},
 	{Event: RepoFlagSuppliedRepoMalformed, Description: "Repos passed via the --repo flag that were malformed (missing their Github org prefix?) and therefore unprocessable"},
-	{Event: RepoNotCompatibleWithPullConfig, Description: "Repos where the submitted pull request configuration is not compatible with the repo"},
+	{Event: RepoDoesntSupportDraftPullRequestsErr, Description: "Repos that do not support Draft PRs (--draft flag was passed)"},
 }
 
 // RunStats will be a stats-tracker class that keeps score of which repos were touched, which were considered for update, which had branches made, PRs made, which were missing workflows or contexts, or had out of date workflows syntax values, etc
@@ -108,6 +108,7 @@ type RunStats struct {
 	repos                 map[types.Event][]*github.Repository
 	skippedArchivedRepos  map[types.Event][]*github.Repository
 	pulls                 map[string]string
+	draftpulls            map[string]string
 	command               []string
 	fileProvidedRepos     []*types.AllowedRepo
 	repoFlagProvidedRepos []*types.AllowedRepo
@@ -125,6 +126,7 @@ func NewStatsTracker() *RunStats {
 		repos:                 make(map[types.Event][]*github.Repository),
 		skippedArchivedRepos:  make(map[types.Event][]*github.Repository),
 		pulls:                 make(map[string]string),
+		draftpulls:            make(map[string]string),
 		command:               []string{},
 		fileProvidedRepos:     fileProvidedRepos,
 		repoFlagProvidedRepos: repoFlagProvidedRepos,
@@ -164,6 +166,11 @@ func (r *RunStats) GetSkippedArchivedRepos() map[types.Event][]*github.Repositor
 // GetPullRequests returns the inner representation of the pull requests that were opened during the lifecycle of a given run
 func (r *RunStats) GetPullRequests() map[string]string {
 	return r.pulls
+}
+
+// GetDraftPullRequests returns the inner representation of the draft pull requests that were opened during the lifecycle of a given run
+func (r *RunStats) GetDraftPullRequests() map[string]string {
+	return r.draftpulls
 }
 
 // SetFileProvidedRepos sets the number of repos that were provided via file by the user on startup (as opposed to looked up via GitHub API via the --github-org flag)
@@ -221,10 +228,20 @@ func TrackEventIfMissing(slice []*github.Repository, repo *github.Repository) []
 	return append(slice, repo)
 }
 
+// TrackPullRequest stores the successful PR opening for the supplied Repo, at the supplied PR URL
+// This function is safe to call from concurrent goroutines
 func (r *RunStats) TrackPullRequest(repoName, prURL string) {
 	defer r.mutex.Unlock()
 	r.mutex.Lock()
 	r.pulls[repoName] = prURL
+}
+
+// TrackDraftPullRequest stores the successful Draft PR opening for the supplied Repo, at the supplied PR URL
+// This function is safe to call from concurrent goroutines
+func (r *RunStats) TrackDraftPullRequest(repoName, prURL string) {
+	defer r.mutex.Unlock()
+	r.mutex.Lock()
+	r.draftpulls[repoName] = prURL
 }
 
 // TrackMultiple accepts a types.Event and a slice of pointers to GitHub repos that will all be associated with that event
@@ -242,7 +259,8 @@ func (r *RunStats) GenerateRunReport() *types.RunReport {
 		Command:        r.command,
 		SelectionMode:  r.selectionMode,
 		RuntimeSeconds: r.GetTotalRunSeconds(), FileProvidedRepos: r.GetFileProvidedRepos(),
-		PullRequests: r.GetPullRequests(),
+		PullRequests:      r.GetPullRequests(),
+		DraftPullRequests: r.GetDraftPullRequests(),
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -23,6 +23,7 @@ type RunReport struct {
 	RuntimeSeconds    int
 	FileProvidedRepos []*AllowedRepo
 	PullRequests      map[string]string
+	DraftPullRequests map[string]string
 }
 
 // AnnotatedEvent is used in printing the final report. It contains the info to print a section's table - both its Event for looking up the tagged repos, and the human-legible description for printing above the table


### PR DESCRIPTION
Hey folks, thanks for the neat tool!

My team is interested in using the GitHub drafts feature so I've implemented a `--draft` flag here.

I played around with a few tests but I didn't find one that felt like it provided meaningful coverage. What we want I think is a test where we check that the PR submitted to [`client.PullRequests.Create`](https://github.com/gruntwork-io/git-xargs/blob/7b8ec9c37a780a0d163010b761074d09ed33b224/repository/repo-operations.go#L448) has the has `Draft: true`, which would require some storage structure on the mock used in perhaps another test like [`TestProcessRepo`](https://github.com/gruntwork-io/git-xargs/blob/b55137d2a13d042ca5930c1b1e1dcca8b24230b9/repository/process_test.go#L16). This did seem like a lot for a flag, so wanted to see what you thought before adding it. Open to any suggestions for testing approaches!

Also looks like my editor removed a couple extra spaces, please let me know if you'd like them reverted.   

closes #47 