### PR TITLE
Repo selection mode enhancements

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -39,6 +39,9 @@ func PrintRepoReport(allEvents []types.AnnotatedEvent, runReport *types.RunRepor
 	fmt.Println()
 	fmt.Println(runReport.Command)
 	fmt.Println()
+	fmt.Println("REPO SELECTION METHOD USED FOR THIS RUN - (see README.md for more information)")
+	fmt.Println()
+	fmt.Println(runReport.SelectionMode)
 
 	// If the user selected repos via a flat file, print a table showing which repos they were
 	if len(runReport.FileProvidedRepos) > 0 {

--- a/types/types.go
+++ b/types/types.go
@@ -19,6 +19,7 @@ type RunReport struct {
 	Repos             map[Event][]*github.Repository
 	SkippedRepos      map[Event][]*github.Repository
 	Command           []string
+	SelectionMode     string
 	RuntimeSeconds    int
 	FileProvidedRepos []*AllowedRepo
 	PullRequests      map[string]string
@@ -58,6 +59,12 @@ type NoRepoSelectionsMadeErr struct{}
 
 func (NoRepoSelectionsMadeErr) Error() string {
 	return fmt.Sprint("You must target some repos for processing either via stdin or by providing one of the --github-org, --repos, or --repo flags")
+}
+
+type NoRepoFlagTargetsValid struct{}
+
+func (NoRepoFlagTargetsValid) Error() string {
+	return fmt.Sprint("None of the repos specified via the --repo flag are valid. Please double-check you have included the Github org prefix for each - e.g. --repo gruntwork-io/git-xargs")
 }
 
 type NoBranchNameErr struct{}


### PR DESCRIPTION
Fixes #50 

- Make the selection mode used by git-xargs explicit in the report
- Add more explicit error handling when all --repo or STDIN repos are
malformed
- These changes should make it easier to grok what git-xargs is doing
and why when it comes to --github-org being preferred, or user-supplied
inputs being malformed