### PR TITLE
Feature/base branch name 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Passing the `--branch-name` (`-b`) flag is required when running `git-xargs`. If
 
 ## Default repository branch
 
-Any pull requests opened will be opened against the repository's default branch (whether that's `main`, or `master` or something else).
+Any pull requests opened will be opened against the repository's default branch (whether that's `main`, or `master` or something else). You can supply an additional `--base-branch-name` flag to change the target for your pull requests. Be aware that this will override the base branch name for **ALL** targetted repositories.
 
 ## Git file staging behavior
 

--- a/cmd/git-xargs.go
+++ b/cmd/git-xargs.go
@@ -25,6 +25,7 @@ func parseGitXargsConfig(c *cli.Context) (*config.GitXargsConfig, error) {
 	config.SkipPullRequests = c.Bool("skip-pull-requests")
 	config.SkipArchivedRepos = c.Bool("skip-archived-repos")
 	config.BranchName = c.String("branch-name")
+	config.BaseBranchName = c.String("base-branch-name")
 	config.CommitMessage = c.String("commit-message")
 	config.PullRequestTitle = c.String("pull-request-title")
 	config.PullRequestDescription = c.String("pull-request-description")

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type GitXargsConfig struct {
 	SkipArchivedRepos      bool
 	MaxConcurrentRepos     int
 	BranchName             string
+	BaseBranchName         string
 	CommitMessage          string
 	PullRequestTitle       string
 	PullRequestDescription string
@@ -40,6 +41,7 @@ func NewGitXargsConfig() *GitXargsConfig {
 		SkipArchivedRepos:      false,
 		MaxConcurrentRepos:     0,
 		BranchName:             "",
+		BaseBranchName:         "",
 		CommitMessage:          common.DefaultCommitMessage,
 		PullRequestTitle:       common.DefaultPullRequestTitle,
 		PullRequestDescription: common.DefaultPullRequestDescription,

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -390,8 +390,11 @@ func openPullRequest(config *config.GitXargsConfig, repo *github.Repository, bra
 		}).Debug("--dry-run and / or --skip-pull-requests is set to true, so skipping opening a pull request!")
 		return nil
 	}
+	repoDefaultBranch := config.BaseBranchName
+	if repoDefaultBranch == "" {
+		repoDefaultBranch = repo.GetDefaultBranch()
+	}
 
-	repoDefaultBranch := repo.GetDefaultBranch()
 	pullRequestAlreadyExists, err := pullRequestAlreadyExistsForBranch(config, repo, branch, repoDefaultBranch)
 
 	if err != nil {


### PR DESCRIPTION
Support overriding base branch name (Follow up to https://github.com/gruntwork-io/git-xargs/issues/22)

<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Since our git workflow uses multiple branches of the same repository in some places, I thought it would make sense to support an optional argument for overriding the base branch name globally (might be an addition to #22).

### Documentation

- README
- `--base-branch-name=<xxx>`

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.


## Related Issues

#22
