### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brikis98 @zackproser
+@yorinasub17 @zackproser @rhoboat

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@yorinasub17 @zackproser @rhoboat
+* @brikis98 @yorinasub17 @zackproser @rhoboat


### PR DESCRIPTION
Adds the IaC US team engineers to CODEOWNERS and removes others. Addresses https://github.com/gruntwork-io/cloud-chasers/issues/27. We should add back the maintenance tier owners as well.