### PR TITLE
Make printed table markdown-friendly

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -14,10 +14,10 @@ import (
 // configurePrinterStyling accepts a pointer to a table printer and sets up the styles commonly used across them
 // resulting in uniform tabular output to STDOUT following each run of the CLI
 func configurePrinterStyling(printer *tableprinter.Printer) {
-	printer.BorderTop, printer.BorderBottom, printer.BorderLeft, printer.BorderRight = true, true, true, true
-	printer.CenterSeparator = "│"
-	printer.ColumnSeparator = "│"
-	printer.RowSeparator = "─"
+	printer.BorderTop, printer.BorderBottom, printer.BorderLeft, printer.BorderRight = false, false, true, true
+	printer.CenterSeparator = "|"
+	printer.ColumnSeparator = "|"
+	printer.RowSeparator = "-"
 	printer.HeaderBgColor = tablewriter.BgBlackColor
 	printer.HeaderFgColor = tablewriter.FgGreenColor
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This change uses different characters for the pipe and hyphen when printing tables and removes the top and bottom borders.

Not sure if this makes sense to all users. The table may not look as nice in the CLI, but it can be more easily copy-pasted into GitHub issues/PRs and other markdown needs. It doesn't seem worth having a separate `--render-markdown` flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated the table outputs to be markdown friendly.

### Migration Guide

(I don't think this warrants a migration guide even though changes are made to outputs.)
