### PR TITLE
Add support for GH enterprise

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/google/go-github/v43/github"
@@ -51,8 +52,21 @@ func ConfigureGithubClient() GithubClient {
 
 	tc := oauth2.NewClient(context.Background(), ts)
 
+	GithubEnterpriseHostname := os.Getenv("GITHUB_ENTERPRISE_HOSTNAME")
+
+	var githubClient *github.Client
+	if GithubEnterpriseHostname != "" {
+		githubClient, _ = github.NewEnterpriseClient(
+			fmt.Sprintf("https://%s/api/v3/", GithubEnterpriseHostname),
+			fmt.Sprintf("https://%s/api/uploads/", GithubEnterpriseHostname),
+			tc,
+		)
+	} else {
+		githubClient = github.NewClient(tc)
+	}
+
 	// Wrap the go-github client in a GithubClient struct, which is common between production and test code
-	client := NewClient(github.NewClient(tc))
+	client := NewClient(githubClient)
 
 	return client
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add support for Github Enterprise usage.

I needed something like this and I saw that the project had an issue to make this happen.

So I wanted to propose a quick Pr and get feedback on what you expect from the PR
Some questions
- Should I add tests at this integration level?
- Any specific docs I should be aware of updating?

Relates #5

<!-- Description of the changes introduced by this PR. -->

## TODOs
- Change the branch to the expected format
- Add tests as required in this PR
- Update docs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added support for github enterprise

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
