### PR TITLE
feat: add support for github enterprise server

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ $ brew install git-xargs
       export GITHUB_OAUTH_TOKEN=<your-secret-github-oauth-token>
       ```
 
+1. **Setup authentication with your Github Enterprise server**. To use a Github Enterprise server, set the GITHUB_HOSTNAME environment variable:
+      ```bash
+      export GITHUB_HOSTNAME=<your-ghe-hostname.your-domain.com>
+      ```
+
 1. **Provide a script or command and target some repos**. Here's a simple example of running the `touch` command in
    every repo in your GitHub organization. Follow the same pattern to start running your own scripts and commands
    against your own repos!
@@ -203,6 +208,7 @@ $ brew install git-xargs
         --github-org <enter-your-github-org-name> \
         touch git-xargs-is-awesome.txt
       ```
+
 
 # Reference
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -2,12 +2,12 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/google/go-github/v43/github"
 	"github.com/gruntwork-io/git-xargs/types"
 	"github.com/gruntwork-io/go-commons/errors"
-
 	"golang.org/x/oauth2"
 )
 
@@ -52,8 +52,20 @@ func ConfigureGithubClient() GithubClient {
 
 	tc := oauth2.NewClient(context.Background(), ts)
 
+	var githubClient *github.Client
+
+	if os.Getenv("GITHUB_HOSTNAME") != "" {
+		GithubHostname := os.Getenv("GITHUB_HOSTNAME")
+		baseUrl := fmt.Sprintf("https://%s/", GithubHostname)
+
+		githubClient, _ = github.NewEnterpriseClient(baseUrl, baseUrl, tc)
+
+	} else {
+		githubClient = github.NewClient(tc)
+	}
+
 	// Wrap the go-github client in a GithubClient struct, which is common between production and test code
-	client := NewClient(github.NewClient(tc))
+	client := NewClient(githubClient)
 
 	return client
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -8,11 +8,23 @@ import (
 )
 
 // TestConfigureGithubClient performs a sanity check that you can configure a production GitHub API client
+// If GITHUB_HOSTNAME, use the github.NewEnterpriseClient
 func TestConfigureGithubClient(t *testing.T) {
 	t.Parallel()
 
-	client := ConfigureGithubClient()
-	assert.NotNil(t, client)
+	t.Run("returns github client", func(t *testing.T) {
+		client := ConfigureGithubClient()
+		assert.NotNil(t, client)
+	})
+	t.Run("returns github client with GithubHostname", func(t *testing.T) {
+		GithubHostname := "ghe.my-domain.com"
+		os.Setenv("GITHUB_HOSTNAME", GithubHostname)
+
+		client := ConfigureGithubClient()
+		assert.NotNil(t, client)
+
+	})
+
 }
 
 // TestNoGithubOauthTokenPassed temporarily drops the existing GITHUB_OAUTH_TOKEN env var to ensure that the validation


### PR DESCRIPTION

## Description

This PR adds support for Github Enterprise. I used this [PR](https://github.com/gruntwork-io/git-xargs/pull/105) as a guide, and added a small test.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added support for Github Enterprise servers.


