### PR TITLE
Update CircleCI config to sign MacOS binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: build-go-binaries --app-name git-xargs --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
+      - run: build-go-binaries --app-name git-xargs --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
       - persist_to_workspace:
           root: .
           paths: bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,14 +117,24 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
-      - build-and-deploy:
+      - build:
           requires:
             - test
           filters:
             tags:
               only: /^v.*/
-            branches: 
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
               ignore: /.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
+            - APPLE__OSX__code-signing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,3 @@
-orbs:
-  go: circleci/go@1.7.3
 env: &env
   environment:
     TERRATEST_LOG_PARSER_VERSION: NONE
@@ -24,8 +22,10 @@ install_gruntwork_utils: &install_gruntwork_utils
     --terraform-version ${TERRAFORM_VERSION} \
     --terragrunt-version ${TERRAGRUNT_VERSION} \
     --packer-version ${PACKER_VERSION} \
-    --go-version ${GOLANG_VERSION} 
-version: 2
+    --go-version ${GOLANG_VERSION}
+orbs:
+  go: circleci/go@1.7.3
+version: 2.1
 jobs:
   pre-commit:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,20 @@
-defaults: &defaults
-  docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.18-tf1.4-tg39.1-pck1.8-ci50.7
-  environment: 
+orbs:
+  go: circleci/go@1.7.3
+env: &env
+  environment:
     TERRATEST_LOG_PARSER_VERSION: NONE
     TERRAFORM_VERSION: NONE
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: NONE
-    GRUNTWORK_INSTALLER_VERSION: v0.0.35
-    MODULE_CI_VERSION: v0.33.1
+    GRUNTWORK_INSTALLER_VERSION: v0.0.39
+    MODULE_CI_VERSION: v0.52.6
     GOLANG_VERSION: 1.18
     GO111MODULE: auto
     CGO_ENABLED: 1
+defaults: &defaults
+  docker:
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.18-tf1.4-tg39.1-pck1.8-ci50.7
+  <<: *env
 install_gruntwork_utils: &install_gruntwork_utils
   name: Install gruntwork utils
   command: |
@@ -48,15 +52,51 @@ jobs:
           command: run-go-tests --timeout 5m
           no_output_timeout: 45m
           when: always
-  build-and-deploy:
+  build:
+    resource_class: large
     <<: *defaults
     steps:
       - checkout
-      - run: 
-          <<: *install_gruntwork_utils
-      - run: build-go-binaries --app-name git-xargs --src-path ./ --dest-path bin --ld-flags "-X main.VERSION=$CIRCLE_TAG"
-      - run: cd bin && sha256sum * > SHA256SUMS
-      - run: upload-github-release-assets bin/* 
+      - run: build-go-binaries --app-name git-xargs --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.Version=$CIRCLE_TAG -extldflags '-static'"
+      - persist_to_workspace:
+          root: .
+          paths: bin
+  deploy:
+    <<: *env
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.x86.medium.gen2
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - go/install:
+          version: "1.20.5"
+      - run:
+          name: Install sign-binary-helpers
+          command: |
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
+      - run:
+          name: Compile and sign the binaries
+          command: |
+            sign-binary --install-macos-sign-dependencies --os mac .gon_amd64.hcl
+            sign-binary --os mac .gon_arm64.hcl
+            echo "Done signing the binary"
+
+            # Replace the files in bin. These are the same file names generated from .gon_amd64.hcl and .gon_arm64.hcl
+            unzip git-xargs_darwin_amd64.zip
+            mv git-xargs_darwin_amd64 bin/
+
+            unzip git-xargs_darwin_arm64.zip
+            mv git-xargs_darwin_arm64 bin/
+      - run:
+          name: Run SHA256SUM
+          command: |
+            brew install coreutils
+            cd bin && sha256sum * > SHA256SUMS
+      - run: upload-github-release-assets bin/*
 workflows:
   version: 2
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,8 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci

--- a/.gon_amd64.hcl
+++ b/.gon_amd64.hcl
@@ -1,0 +1,19 @@
+# See https://github.com/gruntwork-io/terraform-aws-ci/blob/main/modules/sign-binary-helpers/
+# for further instructions on how to sign the binary + submitting for notarization.
+
+source = ["./bin/git-xargs_darwin_amd64"]
+
+bundle_id = "io.gruntwork.app.terragrunt"
+
+apple_id {
+  username = "machine.apple@gruntwork.io"
+  password = "@env:MACOS_AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Gruntwork, Inc."
+}
+
+zip {
+  output_path = "git-xargs_darwin_amd64.zip"
+}

--- a/.gon_arm64.hcl
+++ b/.gon_arm64.hcl
@@ -1,0 +1,19 @@
+# See https://github.com/gruntwork-io/terraform-aws-ci/blob/main/modules/sign-binary-helpers/
+# for further instructions on how to sign the binary + submitting for notarization.
+
+source = ["./bin/git-xargs_darwin_arm64"]
+
+bundle_id = "io.gruntwork.app.terragrunt"
+
+apple_id {
+  username = "machine.apple@gruntwork.io"
+  password = "@env:MACOS_AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Gruntwork, Inc."
+}
+
+zip {
+  output_path = "git-xargs_darwin_arm64.zip"
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We are already able to sign the binaries of internal projects, like [patcher-cli](https://github.com/gruntwork-io/patcher-cli/releases) and [terrapatch-cli](https://github.com/gruntwork-io/terrapatch-cli).

I am replicating the same process in git-xargs, the MacOS binaries will be signed and notarized before generating the `sha256sum`. 

Related:
- https://github.com/gruntwork-io/terragrunt/pull/2661
- https://github.com/gruntwork-io/cloud-nuke/pull/559
- https://github.com/gruntwork-io/kubergrunt/pull/209

Test release: https://github.com/gruntwork-io/git-xargs/releases/tag/v0.1.10-test-signing-binaries

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.


## Release Notes (draft)

Signing MacOS binaries from now on! 🎉

