### PR TITLE
Bugfix checkouting existing branch. Fixes issue #109

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ If your job is consistently being rate-limited, try incrementally increasing the
 
 ## Branch behavior
 
-Passing the `--branch-name` (`-b`) flag is required when running `git-xargs`. If you specify the name of a branch that exists on your remote, its latest changes will be pulled locally prior to your command or script being run. If you specify the name of a new branch that does not yet exist on your remote, it will be created locally and pushed once your changes are committed.
+Passing the `--branch-name` (`-b`) flag is required when running `git-xargs`. If you specify the name of a branch that exists on your remote, it is checkout locally prior to your command or script being run. If you specify the name of a new branch that does not yet exist on your remote, it will be created locally and pushed once your changes are committed.
 
 ## Default repository branch
 

--- a/repository/repo-operations.go
+++ b/repository/repo-operations.go
@@ -177,7 +177,7 @@ func checkoutLocalBranch(config *config.GitXargsConfig, ref *plumbing.Reference,
 		},
 	})
 
-	if fetchRemoteBranchesErr != nil {
+	if fetchRemoteBranchesErr != git.NoErrAlreadyUpToDate && fetchRemoteBranchesErr != nil {
 		logger.WithFields(logrus.Fields{
 			"Error": fetchRemoteBranchesErr,
 			"Repo":  remoteRepository.GetName(),

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -62,8 +62,8 @@ const (
 	CommitsMadeDirectlyToBranch types.Event = "commits-made-directly-to-branch"
 	// DirectCommitsPushedToRemoteBranch denotes a repo whose changes were pushed to the remote specified branch because the --skip-pull-requests flag was passed
 	DirectCommitsPushedToRemoteBranch types.Event = "direct-commits-pushed-to-remote"
-	// BranchRemotePullFailed denotes a repo whose remote branch could not be fetched successfully
-	BranchRemotePullFailed types.Event = "branch-remote-pull-failed"
+	// BranchRemoteFetchFailed denotes a repo whose remote branch could not be fetched successfully
+	BranchRemoteFetchFailed types.Event = "branch-remote-fetch-failed"
 	// BranchRemoteDidntExistYet denotes a repo whose specified branch didn't exist remotely yet and so was just created locally to begin with
 	BranchRemoteDidntExistYet types.Event = "branch-remote-didnt-exist-yet"
 	// RepoFlagSuppliedRepoMalformed denotes a repo passed via the --repo flag that was malformed (perhaps missing it's Github org prefix) and therefore unprocessable
@@ -104,7 +104,7 @@ var allEvents = []types.AnnotatedEvent{
 	{Event: PullRequestAlreadyExists, Description: "Repos where opening a pull request was skipped because a pull request was already open"},
 	{Event: CommitsMadeDirectlyToBranch, Description: "Repos whose local changes were committed directly to the specified branch because --skip-pull-requests was passed"},
 	{Event: DirectCommitsPushedToRemoteBranch, Description: "Repos whose changes were pushed directly to the remote branch because --skip-pull-requests was passed"},
-	{Event: BranchRemotePullFailed, Description: "Repos whose remote branches could not be successfully pulled"},
+	{Event: BranchRemoteFetchFailed, Description: "Repos whose remote branches could not be successfully fetched"},
 	{Event: BranchRemoteDidntExistYet, Description: "Repos whose specified branches did not exist on the remote, and so were first created locally"},
 	{Event: RepoFlagSuppliedRepoMalformed, Description: "Repos passed via the --repo flag that were malformed (missing their Github org prefix?) and therefore unprocessable"},
 	{Event: RepoDoesntSupportDraftPullRequestsErr, Description: "Repos that do not support Draft PRs (--draft flag was passed)"},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #109.

Original code did equivalent of following:

```bash
git clone <some repo>
git checkout -b <branch name>
git merge --ff origin/<branch name>
```
new code is properly checkouting remote branch if exists
```bash
git clone <some repo>
git fetch
# Try to checkout remote branch
git checkout <branch name>
# If above command fails then new branch is created
git checkout -b <branch name>
```
Problem with original code is not only that's not convenient, but it's as well bugy, it's silently supposing that `<branch name>` was created on top of default remote branch name plus it's supposing remote branch name wasn't changed in meanwhile until remote `<branch name>` was created. Ofc this conditions are often not met and thats the case when the bug #109 appears.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed #109 checkout remote branch locally if exists. 

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
