### PR TITLE
fix: --skip-archived-repos does not filter correctly

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -16,6 +16,7 @@ var (
 	repoName2 = "terratest"
 	repoName3 = "fetch"
 	repoName4 = "terraform-kubernetes-helm"
+	repoName5 = "terraform-google-load-balancer"
 )
 
 var (
@@ -23,6 +24,7 @@ var (
 	repoURL2 = "https://github.com/gruntwork-io/terratest"
 	repoURL3 = "https://github.com/gruntwork-io/fetch"
 	repoURL4 = "https://github.com/gruntwork-io/terraform-kubernetes-helm"
+	repoURL5 = "https://github.com/gruntwork-io/terraform-google-load-balancer"
 )
 
 var archivedFlag = true
@@ -55,6 +57,14 @@ var MockGithubRepositories = []*github.Repository{
 		},
 		Name:     &repoName4,
 		HTMLURL:  &repoURL4,
+		Archived: &archivedFlag,
+	},
+	{
+		Owner: &github.User{
+			Login: &ownerName,
+		},
+		Name:     &repoName5,
+		HTMLURL:  &repoURL5,
 		Archived: &archivedFlag,
 	},
 }

--- a/repository/fetch-repos.go
+++ b/repository/fetch-repos.go
@@ -91,8 +91,8 @@ func getReposByOrg(config *config.GitXargsConfig) ([]*github.Repository, error) 
 		}
 
 		// github.RepositoryListByOrgOptions doesn't seem to be able to filter out archived repos
-		// So re-slice the repos list if --skip-archived-repos is passed and the repository is in archived/read-only state
-		for i, repo := range repos {
+		// So filter the repos list if --skip-archived-repos is passed and the repository is in archived/read-only state
+		for _, repo := range repos {
 			if config.SkipArchivedRepos && repo.GetArchived() {
 				logger.WithFields(logrus.Fields{
 					"Name": repo.GetFullName(),
@@ -100,10 +100,8 @@ func getReposByOrg(config *config.GitXargsConfig) ([]*github.Repository, error) 
 
 				// Track repos to skip because of archived status for our final run report
 				config.Stats.TrackSingle(stats.ReposArchivedSkipped, repo)
-
-				reposToAdd = append(repos[:i], repos[i+1:]...)
 			} else {
-				reposToAdd = repos
+				reposToAdd = append(reposToAdd, repo)
 			}
 		}
 

--- a/repository/fetch-repos_test.go
+++ b/repository/fetch-repos_test.go
@@ -63,6 +63,6 @@ func TestSkipArchivedRepos(t *testing.T) {
 
 	githubRepos, reposByOrgLookupErr := getReposByOrg(config)
 
-	assert.Equal(t, len(githubRepos), len(mocks.MockGithubRepositories)-1)
+	assert.Equal(t, len(githubRepos), len(mocks.MockGithubRepositories)-2)
 	assert.NoError(t, reposByOrgLookupErr)
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/git-xargs/issues/158

Fixes filtering logic for `--skip-archived-repos`. This logic was incorrect, causing some archived repos to be present in the result even though `--skip-archived-repos` was passed.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Fixed a bug in the filtering logic for skipping archived repos.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
None