### PR TITLE
bump module version and xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ env: &env
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: NONE
     GRUNTWORK_INSTALLER_VERSION: v0.0.39
-    MODULE_CI_VERSION: v0.53.3
+    MODULE_CI_VERSION: v0.57.3
     GOLANG_VERSION: 1.21.1
     GO111MODULE: auto
     CGO_ENABLED: 1
@@ -64,7 +64,7 @@ jobs:
   deploy:
     <<: *env
     macos:
-      xcode: 14.2.0
+      xcode: 15.3.0
     resource_class: macos.m1.medium.gen1
     steps:
       - checkout


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

seeing this error on [deploy](https://app.circleci.com/pipelines/github/gruntwork-io/git-xargs/375/workflows/868a3720-74af-4810-b267-85636db2ed89/jobs/667):

```
Signing .gon_amd64.hcl
/usr/local/bin/sign-binary: line 231: /tmp/gon/gon: Bad CPU type in executable

Exited with code exit status 1
```

i believe [this comment](https://github.com/gruntwork-io/git-xargs/pull/156#pullrequestreview-2280308768) was right, we do need to bump these versions. 


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes 

bump module version and xcode version in circle ci config

