### PR TITLE
fix bug when skipping archived repos

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -16,6 +16,7 @@ var (
 	repoName2 = "terratest"
 	repoName3 = "fetch"
 	repoName4 = "terraform-kubernetes-helm"
+	repoName5 = "terraform-google-load-balancer"
 )
 
 var (
@@ -23,6 +24,7 @@ var (
 	repoURL2 = "https://github.com/gruntwork-io/terratest"
 	repoURL3 = "https://github.com/gruntwork-io/fetch"
 	repoURL4 = "https://github.com/gruntwork-io/terraform-kubernetes-helm"
+	repoURL5 = "https://github.com/gruntwork-io/terraform-google-load-balancer"
 )
 
 var archivedFlag = true
@@ -55,6 +57,14 @@ var MockGithubRepositories = []*github.Repository{
 		},
 		Name:     &repoName4,
 		HTMLURL:  &repoURL4,
+		Archived: &archivedFlag,
+	},
+	{
+		Owner: &github.User{
+			Login: &ownerName,
+		},
+		Name:     &repoName5,
+		HTMLURL:  &repoURL5,
 		Archived: &archivedFlag,
 	},
 }

--- a/repository/fetch-repos_test.go
+++ b/repository/fetch-repos_test.go
@@ -63,6 +63,6 @@ func TestSkipArchivedRepos(t *testing.T) {
 
 	githubRepos, reposByOrgLookupErr := getReposByOrg(config)
 
-	assert.Equal(t, len(githubRepos), len(mocks.MockGithubRepositories)-1)
+	assert.Equal(t, len(githubRepos), len(mocks.MockGithubRepositories)-2)
 	assert.NoError(t, reposByOrgLookupErr)
 }


### PR DESCRIPTION

## Description

Fixes #158.

See #157 for original documentation. Thanks @schmidlidev for the find!

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixed a bug in the filtering logic for skipping archived repos.

